### PR TITLE
Tronador - Add details about git auth Secrets format in TronadorConfig

### DIFF
--- a/docs/content/sre/tronador/tronador_config.md
+++ b/docs/content/sre/tronador/tronador_config.md
@@ -136,8 +136,6 @@ spec:
 - **`authSecret`**: Name of the Secret required in case of a private repository. If this field is not filled, it will be treated as a public repository.
 - **`imagePullSecret`**: Name of the Secret required to access the image repository where the application's images are hosted, e.g. Nexus or Docker.
 
-Note: The Secrets mentioned under `mappings.authSecret` and `mappings.imagePullSecret` will only be created in the relevant Environments' namespaces, and not in any other namespaces. The relevant Environments are those that are based on the repositories mentioned in `mappings.repos`.
-
 ### orgLevelSecrets
 
 `orgLevelSecrets` contains Secrets that are to be used as default Secrets for any repositories that do not have their name mentioned in a mapping. This field can prove useful in case there are a large number of repositories that share the same Secret(s), and it is infeasible to write all of the repository names in a mapping.
@@ -208,3 +206,4 @@ stringData:
 - If namespace is set in any resource, Tronador will ignore it and only deploy the resource to the relevant namespace (see mappings section above).
 - Tronador will only apply resources from the TronadorConfig CR present in the operator Namespace, and named `tronador-config`.
 - TronadorConfig points to default `admin` ClusterRole of OpenShift; all the namespaced resources allowed by that ClusterRole will be applied in the Namespaces.
+- The Secrets mentioned under `mappings.authSecret` and `mappings.imagePullSecret` will only be created in the relevant Environments' namespaces, and not in any other namespaces. The relevant Environments are those that are based on the repositories mentioned in `mappings.repos`.

--- a/docs/content/sre/tronador/tronador_config.md
+++ b/docs/content/sre/tronador/tronador_config.md
@@ -186,7 +186,7 @@ data:
 
 ##### SSH authentication
 
-To authenticate towards a Git repository over SSH, the referenced Secret is expected to contain identity and known_hosts fields. With the respective private key of the SSH key pair, and the host keys of the Git repository.
+To authenticate towards a Git repository over SSH, the referenced Secret is expected to contain identity and `known_hosts` fields. With the respective private key of the SSH key pair, and the host keys of the Git repository.
 
 ```yaml
 apiVersion: v1

--- a/docs/content/sre/tronador/tronador_config.md
+++ b/docs/content/sre/tronador/tronador_config.md
@@ -136,22 +136,72 @@ spec:
 - **`authSecret`**: Name of the Secret required in case of a private repository. If this field is not filled, it will be treated as a public repository.
 - **`imagePullSecret`**: Name of the Secret required to access the image repository where the application's images are hosted, e.g. Nexus or Docker.
 
+Note: The Secrets mentioned under `mappings.authSecret` and `mappings.imagePullSecret` will only be created in the relevant Environments' namespaces, and not in any other namespaces. The relevant Environments are those that are based on the repositories mentioned in `mappings.repos`.
 
 ### orgLevelSecrets
 
 `orgLevelSecrets` contains Secrets that are to be used as default Secrets for any repositories that do not have their name mentioned in a mapping. This field can prove useful in case there are a large number of repositories that share the same Secret(s), and it is infeasible to write all of the repository names in a mapping.
 
-`orgLevelSecrets` contains two subfields: 
-- **`authSecret`**: Name of the Secret required to access a private repository. 
+`orgLevelSecrets` contains two subfields:
+- **`authSecret`**: Name of the Secret required to access a private repository.
 - **`imagePullSecret`**: Name of the Secret required to access the image repository where the application's images are hosted, e.g. Nexus or Docker.
 
-`orgLevelSecrets` and both of its sub-fields are optional. 
+`orgLevelSecrets` and both of its sub-fields are optional.
 
 
 ### secrets
 
 Manifests inside `secrets` are a list of k8s resources which are required in DTEs for their proper functioning. These resources should only contain Secrets, or resources that can create Secrets in the cluster (in the same namespace as the Environment namespace). In case of the latter, the name of the resource **must** be the same as the name of the generated Secret. `secrets` is a required field if TronadorConfig is created.
 
+#### Using Secrets to connect to a Git repository
+
+##### Basic Access Authentication
+
+To authenticate towards a Git repository over HTTPS using basic access authentication (in other words: using a username and password), the referenced Secret is expected to contain .data.username and .data.password values.
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: basic-access-auth
+type: Opaque
+data:
+  username: <BASE64>
+  password: <BASE64>
+```
+##### HTTPS Certificate Authority
+
+To provide a Certificate Authority to trust while connecting with a Git repository over HTTPS, the referenced Secret can contain a .data.caFile value.
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: https-ca-credentials
+  namespace: default
+type: Opaque
+data:
+  caFile: <BASE64>
+```
+
+##### SSH authentication
+
+To authenticate towards a Git repository over SSH, the referenced Secret is expected to contain identity and known_hosts fields. With the respective private key of the SSH key pair, and the host keys of the Git repository.
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ssh-credentials
+type: Opaque
+stringData:
+  identity: |
+    -----BEGIN OPENSSH PRIVATE KEY-----
+    ...
+    -----END OPENSSH PRIVATE KEY-----
+  known_hosts: |
+        github.com ecdsa-sha2-nistp256 AAAA...
+```
 
 ## Points to be considered while applying TronadorConfig
 - Tronador and all Environments would throw errors in case any cluster-wide resource is mentioned in the TronadorConfig.


### PR DESCRIPTION
Tronador docs - Add details about the format git auth Secrets in TronadorConfig, e.g. A secret containing a SSH key