### PR TITLE
404 page

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -67,7 +67,10 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-        
+        with:
+          driver-opts: image=moby/buildkit:v0.11.1
+          buildkitd-flags: --debug
+
       - name: Login to Registry
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -68,7 +68,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
         with:
-          driver-opts: image=moby/buildkit:v0.11.1
+          driver-opts: image=moby/buildkit:v0.10.6
           buildkitd-flags: --debug
 
       - name: Login to Registry

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
         with:
-          driver-opts: image=moby/buildkit:v0.11.1
+          driver-opts: image=moby/buildkit:v0.10.6
           buildkitd-flags: --debug
 
       - name: Login to Registry

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -35,7 +35,10 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-        
+        with:
+          driver-opts: image=moby/buildkit:v0.11.1
+          buildkitd-flags: --debug
+
       - name: Login to Registry
         uses: docker/login-action@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,4 @@
-FROM python:3.8-alpine
-
-LABEL name="Stakater Cloud Documentation" \
-      maintainer="Stakater <hello@stakater.com>" \
-      vendor="Stakater" \
-      release="1" \
-      summary="Documentation for Stakater Cloud"
+FROM python:3.11-alpine as builder
 
 RUN pip3 install mkdocs-material mkdocs-mermaid2-plugin
 
@@ -18,8 +12,19 @@ COPY --chown=1001:root . .
 # build the docs
 RUN mkdocs build
 
+FROM nginxinc/nginx-unprivileged:1.23-alpine as deploy
+COPY --from=builder $HOME/application/site/ /usr/share/nginx/html/
+COPY default.conf /etc/nginx/conf.d/
+
 # set non-root user
 USER 1001
 
-EXPOSE 8080
-CMD ["python", "-m", "http.server", "8080", "-d", "./site"]
+LABEL name="Stakater Cloud Documentation" \
+      maintainer="Stakater <hello@stakater.com>" \
+      vendor="Stakater" \
+      release="1" \
+      summary="Documentation for Stakater Cloud"
+
+EXPOSE 8080:8080/tcp
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/custom_theme/404.html
+++ b/custom_theme/404.html
@@ -1,0 +1,6 @@
+{% extends "main.html" %}
+
+{% block content %}
+  <h1>404 - Not found</h1>
+  <p>This page does not exist or may have been deprecated or moved. Please use the search to find anything in the documentation.</p>
+{% endblock %}

--- a/default.conf
+++ b/default.conf
@@ -1,0 +1,9 @@
+server {
+    listen 8080;
+    root /usr/share/nginx/html/;
+    index index.html;
+    error_page 404 /404.html;
+    location = /404.html {
+        internal;
+    }
+}


### PR DESCRIPTION
Switch from Python `http.server` to nginx to serve the content since `http.server` is never meant for production and does not allow for easy 404 override anyway.

This will add a more Stakater-designed 404 response for all pages that does not exist:
![Screenshot 2023-01-24 at 17 20 11](https://user-images.githubusercontent.com/6355577/214348515-65a0bce3-7a62-4731-bcf6-a7f52485c826.png)

The latest version of `buildkit:v0.10.6` is not used due to getting `failed to copy: io: read/write on closed pipe` which is due to https://github.com/docker/build-push-action/issues/761#issuecomment-1398918693. Might have been fixed some hour ago https://github.com/containerd/containerd/pull/7985. They however need to release a new version of https://github.com/containerd/containerd and then add it to https://github.com/moby/buildkit/blob/master/Dockerfile and then release buildkit and then refer to it in the build-push-action, so reverting to an old version of buildkit for now.