### PR TITLE
Handle 4xx client errors

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -17,6 +17,9 @@ jobs:
         uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           config-file: .github/md_config.json
+          use-quiet-mode: 'yes'
+          use-verbose-mode: 'yes'
+          max-depth: 1
   spell_check:
     runs-on: ubuntu-latest
     steps:

--- a/custom_theme/404.html
+++ b/custom_theme/404.html
@@ -1,6 +1,6 @@
 {% extends "main.html" %}
 
 {% block content %}
-  <h1>404 - Not found</h1>
+  <h1>4xx - Page does not exist or has restricted access or rights</h1>
   <p>This page does not exist or may have been deprecated or moved. Please use the search to find anything in the documentation.</p>
 {% endblock %}

--- a/default.conf
+++ b/default.conf
@@ -2,7 +2,7 @@ server {
     listen 8080;
     root /usr/share/nginx/html/;
     index index.html;
-    error_page 404 /404.html;
+    error_page 403 404 /404.html;
     location = /404.html {
         internal;
     }

--- a/docs/content/sre/applications/cloud-native-app.md
+++ b/docs/content/sre/applications/cloud-native-app.md
@@ -395,7 +395,7 @@ Hence, traffic might still flow to the Pod despite it being marked as terminated
 
 The app should stop accepting new requests on all remaining connections, and close these once the outgoing queue is drained.
 
-If you need a refresher on how endpoints are propagated in your cluster, [read this article on how to handle client requests properly](https://freecontent.manning.com/handling-client-requests-properly-with-kubernetes).
+If you need a refresher on how endpoints are propagated in your cluster, [read this article on how to handle client requests properly](https://freecontent.manning.com/handling-client-requests-properly-with-kubernetes/).
 
 ### 2. The app still processes incoming requests in the grace period
 

--- a/docs/content/sre/applications/cloud-native-app.md
+++ b/docs/content/sre/applications/cloud-native-app.md
@@ -395,7 +395,7 @@ Hence, traffic might still flow to the Pod despite it being marked as terminated
 
 The app should stop accepting new requests on all remaining connections, and close these once the outgoing queue is drained.
 
-If you need a refresher on how endpoints are propagated in your cluster, [read this article on how to handle client requests properly](https://freecontent.manning.com/handling-client-requests-properly-with-kubernetes/).
+If you need a refresher on how endpoints are propagated in your cluster, [read this article on how to handle client requests properly](https://freecontent.manning.com/handling-client-requests-properly-with-kubernetes).
 
 ### 2. The app still processes incoming requests in the grace period
 


### PR DESCRIPTION
For example https://docs.stakater.com/content/sre/multi-tenant-operator/ gives 403 Forbidden nginx default error page, while it should return custom error page