### PR TITLE
improve handling of error pages

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -2,9 +2,8 @@ server {
     listen 8080;
     root /usr/share/nginx/html/;
     index index.html;
-    error_page 403 404 /404.html;
-    location = /404.html {
-        internal;
+    location / {
+        try_files $uri $uri/ /404.html;
     }
     location ~* ^/content/sre/multi-tenant-operator(/(.*))?$ {
         return 301 $scheme://docs.stakater.com/mto/$2;


### PR DESCRIPTION
the current version can handle files missing, but it can not handle directories missing.

https://docs.stakater.com/mto/main/reference-guides/admin-clusterrole.html Fails to show a nice looking 404.

https://docs.stakater.com/mto/main/obviously_missing_file succeeds.

With this change, both should work.

Not sure what internal does or if is needed, have tested on a local nginx only.